### PR TITLE
feat: add product info scraping and JSON export

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,3 +46,5 @@ Thumbs.db
 # Docker
 Dockerfile
 .dockerignore
+
+*.json

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+*.json
 MANIFEST
 
 # Virtualenv

--- a/cardrobber.py
+++ b/cardrobber.py
@@ -1,0 +1,124 @@
+import json
+import time
+
+import lxml
+import undetected_chromedriver
+
+from bs4 import BeautifulSoup
+
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+from selenium.webdriver.common.by import By
+
+url = "https://www.ozon.ru/product/shtora-dlya-kuhni-45h137-sm-krasnyy-belyy-2873484548/?at=J8tgZQqj3sYGWppoCgpALvwCM6w3LpTXlv94xHjA53yN&tab=reviews"
+url2 = "https://www.ozon.ru/product/shtora-32h300-sm-belyy-2870181183/?at=lRt6xz1GyuLoRr1JcKwY6NJTkEDo8MhnNAVVmfz3m9AW"
+
+
+
+
+# def get_info_about_orig(url):
+#     with undetected_chromedriver.Chrome() as cr:
+#         cr.get(url)
+#         time.sleep(1)
+#         # Блок кода по получению данных
+#         artik = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[2]/div/div/div/div[2]/button[1]/div").text.split(" ")[1]
+#         name = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[1]/div[1]/div[2]/div/div/div/div[1]/h1").text
+#         # Получаю рейтинг
+#         try:
+#             rating = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[1]/div[1]/div[2]/div/div/div/div[2]/div[1]/button/div").text
+#             if rating == "Нет отзывов":
+#                 rating = 0
+#         except:
+#             rating = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[1]/div[1]/div[2]/div/div/div/div[2]/div[1]/a/div").text.split(" ")[0]
+#         print(3)
+#
+#         # Получаю кол-во отзывов
+#         try:
+#             reviews_num = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[1]/div[1]/div[2]/div/div/div/div[2]/div[1]/button/div").text.lower()
+#         except:
+#             reviews_num = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[1]/div[1]/div[2]/div/div/div/div[2]/div[1]/a/div").text.split("•")[1].strip()
+#         try:
+#             price = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[2]/div/div/div[1]/div[2]/div/div[1]/div/div/div[1]/div/div/div[1]/span").text.split(" ")[0]
+#         except:
+#             try:
+#                 price = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[2]/div/div/div[1]/div[3]/div[1]/div[1]/div/div/div[1]/div/div/div[1]/span[1]").text
+#             except:
+#                 price = 0
+#
+#         full_info = {"id": artik,
+#                      "name": name,
+#                      "rating": rating,
+#                      "reviews_num": reviews_num,
+#                      "price": "".join(list(filter(str.isdigit, price)))
+#                      }
+#         return full_info
+md = {'https://www.ozon.ru/product/shtora-150h260-sm-belyy-2869617131/?at=XQtk2MDEBFGlxgKNFP1JPyksWOpWAVu54x23oCqB8vD9',
+      'https://www.ozon.ru/product/shtora-89h213-sm-rozovyy-2873340485/?at=J8tgZQA9phyVQv0DI0ZP2qNUgVvnyYcqAJLrWty2LkEV',
+      'https://www.ozon.ru/product/komplekt-shtor-shtory-blekaut-600h200-sm-bezhevyy-2869400772/?at=NOtw7MPkVcvJ22G6t219MGquqYqwlLTGVAVy0tJVkXEy',
+      'https://www.ozon.ru/product/shtora-160h210-sm-belyy-2863475530/?at=Z8tXlo8KPhyZRx35U7YAwoAuVMRAJcMG2z6RhVEkpNL',
+      'https://www.ozon.ru/product/shtora-h210-sm-rozovyy-2865982536/?at=Vvtz3Pkq0Tr6OYQmFq4LG4KsMZEqvZHP8Ezo8fY3GzqX'}
+
+def get_info_about(md):
+    emt_l = []
+    chrome_options = undetected_chromedriver.ChromeOptions()
+    chrome_options.add_argument("--disable-extensions")
+    chrome_options.add_argument("--disable-gpu")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--disable-dev-shm-usage")
+    # chrome_options.add_argument("--headless")  # Раскомментируй для фонового режима
+    with undetected_chromedriver.Chrome(options=chrome_options) as cr:
+        for el in md:
+            cr.get(el)
+            time.sleep(1)
+            # Блок кода по получению данных
+            artik = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[2]/div/div/div/div[2]/button[1]/div").text.split(" ")[1]
+            time.sleep(1)
+            name = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[1]/div[1]/div[2]/div/div/div/div[1]/h1").text
+            time.sleep(1)
+            # Получаю рейтинг
+            try:
+                rating = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[1]/div[1]/div[2]/div/div/div/div[2]/div[1]/button/div").text
+                if rating == "Нет отзывов":
+                    rating = 0
+            except:
+                rating = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[1]/div[1]/div[2]/div/div/div/div[2]/div[1]/a/div").text.split(" ")[0]
+            time.sleep(1)
+
+            # Получаю кол-во отзывов
+            try:
+                reviews_num = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[1]/div[1]/div[2]/div/div/div/div[2]/div[1]/button/div").text.lower()
+            except:
+                reviews_num = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[1]/div[1]/div[2]/div/div/div/div[2]/div[1]/a/div").text.split("•")[1].strip()
+            time.sleep(1)
+            try:
+                price = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[2]/div/div/div[1]/div[2]/div/div[1]/div/div/div[1]/div/div/div[1]/span").text.split(" ")[0]
+            except:
+                try:
+                    price = cr.find_element(By.XPATH, "//*[@id='layoutPage']/div[1]/div[3]/div[3]/div[2]/div/div/div[1]/div[3]/div[1]/div[1]/div/div/div[1]/div/div/div[1]/span[1]").text
+                except:
+                    price = 0
+
+            full_info = {"id": artik,
+                         "name": name,
+                         "rating": rating,
+                         "reviews_num": reviews_num,
+                         "price": "".join(list(filter(str.isdigit, price)))
+                         }
+            emt_l.append(full_info)
+        return emt_l
+
+
+if __name__ == "__main__":
+    try:
+        print(get_info_about(md))
+    except Exception as e:
+        print(e)
+
+
+
+
+
+
+
+

--- a/main.py
+++ b/main.py
@@ -3,18 +3,16 @@ import json
 import lxml
 import undetected_chromedriver
 from bs4 import BeautifulSoup
+from slugify import slugify
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
-from fake_useragent import UserAgent
+from cardrobber import get_info_about
 
-agent = UserAgent.random
-
-task_url = "https://www.ozon.ru/"
-item = "шторы"
-
+# task_url = "https://www.ozon.ru/"
+# item = "шторы"
 
 def scroll_func(uc) -> None:
     """
@@ -31,7 +29,7 @@ def scroll_func(uc) -> None:
     time.sleep(2)
 
 
-def get_products_links(url, item) -> list:
+def get_products_links(url = "https://www.ozon.ru/", item = "кукла"):
     """
     Собирает ссылки на товары с сайта Ozon по заданному поисковому запросу.
 
@@ -50,18 +48,17 @@ def get_products_links(url, item) -> list:
         5. Прокручивает страницу для загрузки дополнительных товаров.
         6. Собирает ссылки на товары и возвращает их в виде списка.
     """
-    emt_l = []  # Список для хранения ссылок на товары
+    ml = []
+    emt_d = {}  # Словарь для хранения ссылок на товары
+    unique_set = set()
     with undetected_chromedriver.Chrome() as uc:
         uc.implicitly_wait(10)  # Устанавливаем неявное ожидание для поиска элементов
         uc.get(url)  # Переход на сайт Ozon
         time.sleep(4)
 
         # Поиск поля ввода и кнопки поиска
-        # input_field = uc.find_element(By.CSS_SELECTOR, ".t8n_30.tsBody500Medium")
         input_field = uc.find_element(By.CSS_SELECTOR, 'input[placeholder="Искать на Ozon"]')
-        print(1)
         input_button = uc.find_element(By.CSS_SELECTOR, 'button[aria-label="Поиск"]')
-        print(2)
         input_field.clear()  # Очистка поля ввода
         input_field.send_keys(item)  # Ввод данных
         time.sleep(2)
@@ -76,26 +73,36 @@ def get_products_links(url, item) -> list:
         res.click()
         time.sleep(2)
 
-        for el in range(2):
+        for el in range(1): # Прокрутка, в случае необходимости
             scroll_func(uc)
             links = uc.find_elements(By.CSS_SELECTOR, 'a[href*="/product/"]')
-            for el in links:
-                emt_l.append(el.get_attribute("href"))
+            for el in links[:14]: # Беру срез для упрощения, можно убрать
+                ml.append(el.get_attribute("href"))
+        unique_set = set(ml)
+        for n, el in enumerate(unique_set):
+            emt_d[n] = el
 
         print("Ссылки на товары собраны")
-        print(emt_l)
+
+        with open("products_url.json", "w", encoding="utf-8") as file:
+            json.dump(emt_d, file, indent=4, ensure_ascii= False)
+
+        print("Ссылки на товары сохранены в json")
+
+        return unique_set
 
         uc.quit()  # Завершаем работу
 
-    return emt_l
+def save_products_json(prod_list, item):
+    """Сохраняет список с информацией о товарах в json"""
+    with open(f"about_products_{slugify(item)}.json", "w", encoding="utf-8") as file:
+        json.dump(prod_list, file,indent=4, ensure_ascii=False, )
+    return {"Message": "OK"}
 
-
-# def main():
-#     get_products_links()
 
 if __name__ == "__main__":
     try:
-        # scroll_func(task_url)
-        get_products_links(task_url, item)
+        res = get_info_about(get_products_links())
+        save_products_json(res, "кукла")
     except Exception as e:
         print(e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "selenium (>=4.35.0,<5.0.0)",
     "lxml (>=6.0.1,<7.0.0)",
     "setuptools (>=80.9.0,<81.0.0)",
-    "fake-useragent (>=2.2.0,<3.0.0)"
+    "fake-useragent (>=2.2.0,<3.0.0)",
+    "python-slugify (>=8.0.4,<9.0.0)"
 ]
 
 


### PR DESCRIPTION
feat: add product info scraping and JSON export

This commit introduces functionality to scrape product information
from Ozon (ID, name, rating, reviews, price) and export it to a JSON file.

Key changes:
- New function `get_info_about()` to parse product pages.
- JSON export to save results for further analysis.
- Error handling to avoid crashes during scraping.
- Used `undetected_chromedriver` to bypass bot detection.
